### PR TITLE
Add coalescing operator for viewData property

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -628,7 +628,7 @@ class Column
         if (preg_match('/^editable_if_true_else_readonly:(.*)$/', $state, $matches)) {
             $keyName = $matches[1];
 
-            $state = ($formBuilder->viewData[$keyName] == true) ? 'editable' : 'readonly';
+            $state = ($formBuilder->viewData[$keyName] ?? false) == true ?  'editable' : 'readonly';
         }
 
         $this->stateSpecificType = $this->type;


### PR DESCRIPTION
The array key $keyName sometimes is missing since it's not declared. Coalescing operator and a default value as false will fix an appearing issue while trying to edit concerns for the MSF's